### PR TITLE
Remove workarounds for Zig issue 13013

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ The modules in this library do not have any dependencies except the Zig standard
 ### alt_std.algorithm
 Contains the functions expected in an algorithm module (ala C++ STL/D/etc).  All functions are constrained to operate on slices as the language has not settled on a standardized interface for iterators or ranges.  Note that the current `std.mem` module includes a number of things that would normally go in this module (e.g. `startsWith`, `count`, etc.) and no effort is made to replace/copy these.
 
-## Known Issues
-The stage2 compiler (used by default in all versions after 0.9.1) has [a bug](https://github.com/ziglang/zig/issues/12973) that prevents certain functions from compiling successfully.  You'll see errors like `current master/nightly compiler which will become v0.10 `.  It's recommended that you either use v0.9.1 or pass `-fstage1` during compilation.  This workaround will not be necessary once the underlying issue in the stage2 implementation is resolved.
-
 ## Contribution
 ### Bug Fixes
 If you find a bug, please do report it.  While I will respond to issues on this project, the ideal way to report an issue is to make a merge request with a minimal, failing test case as part of the function's test suite.  If you also have a fix for the code in question, great!


### PR DESCRIPTION
Thanks to @topolarity for pointing out function pointer changes in stage2.  This is now worked around with `std.meta.FnPtr`.